### PR TITLE
Fix skill reference paths for Claude Code compatibility

### DIFF
--- a/mirrord-config/SKILL.md
+++ b/mirrord-config/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: mirrord
+name: mirrord-config
 description: Helps users generate, edit, and validate mirrord.json configuration files for mirrord (MetalBear). Use when the user wants to connect their local process to a Kubernetes environment, configure features (env/fs/network), or needs feedback on an existing mirrord.json. Always ensures output JSON is valid and schema-conformant.
 metadata:
   author: MetalBear
@@ -19,9 +19,11 @@ Generate and validate `mirrord.json` configuration files:
 ## Critical First Steps
 
 **Step 1: Load references**
-Use the `view` tool to read BOTH reference files:
-1. `/mnt/skills/user/mirrord/references/schema.json` - Authoritative JSON Schema
-2. `/mnt/skills/user/mirrord/references/configuration.md` - Configuration reference
+Read BOTH reference files from this skill's `references/` directory:
+1. `references/schema.json` - Authoritative JSON Schema
+2. `references/configuration.md` - Configuration reference
+
+If using absolute paths, these are located relative to this skill's installation directory. Search for them if needed using patterns like `**/mirrord-config/references/*`.
 
 **Step 2: Install mirrord CLI (if not present)**
 ```bash


### PR DESCRIPTION
- The skill is registered as mirrord-config but the SKILL.md declares itself as mirrord. This mismatch likely causes the "Unknown skill" error.
<img width="1203" height="465" alt="Screenshot 2026-01-22 at 7 34 36 am" src="https://github.com/user-attachments/assets/50bbf7da-03c2-43f6-b470-195d930da5b0" />
- using relative paths per spec

- 
