### PR TITLE
Refresh mirrord-config security audit

### DIFF
--- a/skills/mirrord-config/SKILL.md
+++ b/skills/mirrord-config/SKILL.md
@@ -3,7 +3,7 @@ name: mirrord-config
 description: Helps users generate, edit, and validate mirrord.json configuration files for mirrord (MetalBear). Use when the user wants to connect their local process to a Kubernetes environment, configure features (env/fs/network), or needs feedback on an existing mirrord.json. Always ensures output JSON is valid and schema-conformant.
 metadata:
   author: MetalBear
-  version: "1.0"
+  version: "1.1"
 ---
 
 # Mirrord Configuration Skill


### PR DESCRIPTION
## Change
- Bumped  skill metadata version from 1.0 to 1.1.

## Why
- Your security audit page still shows the old auto-install snippet; version bump forces skills.sh/audit re-indexing.

## Notes
- The risky remote install/execution instructions in  have already been removed.

Made with [Cursor](https://cursor.com)