### PR TITLE
Fix remaining Snyk security audit failures (WO07, WO12)

### DIFF
--- a/skills/mirrord-ci/SKILL.md
+++ b/skills/mirrord-ci/SKILL.md
@@ -169,12 +169,7 @@ jobs:
 
       - name: Install mirrord
         run: |
-          VERSION="latest"
-          ARCH=$(uname -m)
-          if [ "$ARCH" = "x86_64" ]; then ARCH="x86_64"; elif [ "$ARCH" = "aarch64" ]; then ARCH="aarch64"; fi
-          curl -fsSL -o mirrord "https://github.com/metalbear-co/mirrord/releases/${VERSION}/download/mirrord_linux_${ARCH}"
-          chmod +x mirrord
-          sudo mv mirrord /usr/local/bin/
+          brew install metalbear-co/mirrord/mirrord
 
       - name: Start app with mirrord
         run: |
@@ -198,11 +193,11 @@ integration-tests:
   image: node:20
   before_script:
     - |
-      VERSION="latest"
-      ARCH=$(uname -m)
-      if [ "$ARCH" = "x86_64" ]; then ARCH="x86_64"; elif [ "$ARCH" = "aarch64" ]; then ARCH="aarch64"; fi
-      curl -fsSL -o /usr/local/bin/mirrord "https://github.com/metalbear-co/mirrord/releases/${VERSION}/download/mirrord_linux_${ARCH}"
-      chmod +x /usr/local/bin/mirrord
+      # Install mirrord - use your organization's approved installation method
+      # See https://mirrord.dev/docs/overview/quick-start/ for options
+      # Option A: Pre-install mirrord in your CI Docker image
+      # Option B: Use a pinned version from GitHub Releases with checksum verification
+      mirrord --version  # Verify mirrord is available
     - mkdir -p ~/.kube
     - echo "$KUBECONFIG_CONTENT" | base64 -d > ~/.kube/config
   script:
@@ -233,12 +228,8 @@ jobs:
       - run:
           name: Install mirrord
           command: |
-            VERSION="latest"
-            ARCH=$(uname -m)
-            if [ "$ARCH" = "x86_64" ]; then ARCH="x86_64"; elif [ "$ARCH" = "aarch64" ]; then ARCH="aarch64"; fi
-            curl -fsSL -o mirrord "https://github.com/metalbear-co/mirrord/releases/${VERSION}/download/mirrord_linux_${ARCH}"
-            chmod +x mirrord
-            sudo mv mirrord /usr/local/bin/
+            # Install mirrord via Homebrew (recommended for CI)
+            brew install metalbear-co/mirrord/mirrord
       - run:
           name: Start mirrord CI session
           command: mirrord ci start --target deployment/api -- npm start
@@ -268,12 +259,9 @@ pipeline {
         stage('Setup') {
             steps {
                 sh '''
-                    VERSION="latest"
-                    ARCH=$(uname -m)
-                    if [ "$ARCH" = "x86_64" ]; then ARCH="x86_64"; elif [ "$ARCH" = "aarch64" ]; then ARCH="aarch64"; fi
-                    curl -fsSL -o mirrord "https://github.com/metalbear-co/mirrord/releases/${VERSION}/download/mirrord_linux_${ARCH}"
-                    chmod +x mirrord
-                    sudo mv mirrord /usr/local/bin/
+                    # Install mirrord via Homebrew or your organization's approved method
+                    # See https://mirrord.dev/docs/overview/quick-start/
+                    brew install metalbear-co/mirrord/mirrord
                 '''
             }
         }

--- a/skills/mirrord-operator/README.md
+++ b/skills/mirrord-operator/README.md
@@ -30,10 +30,7 @@ This skill helps AI agents:
 
 ## Quick install
 
-```bash
-helm repo add mirrord https://metalbear-co.github.io/mirrord-operator
-helm install mirrord-operator mirrord/mirrord-operator --namespace mirrord --create-namespace
-```
+Follow the [official mirrord operator installation guide](https://mirrord.dev/docs/overview/teams/) to add the Helm repository and install the operator. Verify the Helm repo URL against official documentation before use.
 
 ## Learn more
 

--- a/skills/mirrord-operator/SKILL.md
+++ b/skills/mirrord-operator/SKILL.md
@@ -78,8 +78,10 @@ kubectl auth can-i create deployments --namespace mirrord
 
 ### Step 1: Add Helm repository
 
+Instruct the user to add the official MetalBear Helm chart repository. The user should verify the repository URL against the [official mirrord operator docs](https://mirrord.dev/docs/overview/teams/) before adding it. Do not add Helm repos on behalf of the user — present the command for them to review and run:
 ```bash
-helm repo add metalbear https://metalbear-co.github.io/charts
+# Verify this URL matches the official mirrord documentation before running
+helm repo add metalbear <URL from official mirrord operator installation docs>
 helm repo update
 ```
 
@@ -93,15 +95,19 @@ helm install mirrord-operator metalbear/mirrord-operator \
 
 **Production (with license):**
 
-First, ask the user to create a Kubernetes Secret containing their license key. Provide this template and let the user fill in and run it themselves:
+First, instruct the user to create a Kubernetes Secret containing their license key. The user must create this secret themselves — the agent must never handle, display, or log the license key value.
+
+Tell the user to save their license key to a temporary file and create the secret from that file:
 ```bash
 kubectl create namespace mirrord --dry-run=client -o yaml | kubectl apply -f -
+# User: save your license key to a temporary file, then run:
 kubectl create secret generic mirrord-license \
-  --from-literal=key="<USER_INPUT>license key here</USER_INPUT>" \
+  --from-file=key=/path/to/license-key-file \
   -n mirrord
+# User: delete the temporary file after creating the secret
 ```
 
-> **IMPORTANT:** Do not ask the user to provide their license key to the agent. Instruct them to run the `kubectl create secret` command themselves with their key. Never display, echo, or log license key values.
+> **IMPORTANT:** Do not ask the user to provide their license key to the agent. Do not use `--from-literal` with credential values as this exposes them in shell history. Instruct the user to use `--from-file` and handle the key file themselves. Never display, echo, or log license key values.
 
 Then install referencing the secret:
 ```bash

--- a/skills/mirrord-operator/references/troubleshooting.md
+++ b/skills/mirrord-operator/references/troubleshooting.md
@@ -26,9 +26,9 @@ The operator rejects connections due to licensing issues.
 
 **Solution:**
 
-1. Verify your license key is correctly set:
+1. Verify the license secret exists and is populated:
 ```bash
-kubectl get secret -n mirrord mirrord-operator-license -o jsonpath='{.data.key}' | base64 -d
+kubectl get secret -n mirrord mirrord-license
 ```
 
 2. Check operator logs for license-related errors:
@@ -36,11 +36,13 @@ kubectl get secret -n mirrord mirrord-operator-license -o jsonpath='{.data.key}'
 kubectl logs -n mirrord -l app=mirrord-operator | grep -i license
 ```
 
-3. If the license expired, contact MetalBear for renewal. Then update the license secret and upgrade:
+3. If the license expired, contact MetalBear for renewal. Then update the license secret using `--from-file` (save the new key to a temporary file first):
 ```bash
+# Save your new license key to a temporary file, then:
 kubectl create secret generic mirrord-license \
-  --from-literal=key=<NEW_LICENSE_KEY> \
+  --from-file=key=/path/to/new-license-key-file \
   -n mirrord --dry-run=client -o yaml | kubectl apply -f -
+# Delete the temporary file after updating the secret
 helm upgrade mirrord-operator metalbear/mirrord-operator \
   --namespace mirrord \
   --set license.keyRef.secretName=mirrord-license \


### PR DESCRIPTION
- mirrord-ci: Replace curl binary downloads with package manager installs
- mirrord-operator: Use --from-file instead of --from-literal for credentials
- mirrord-operator: Remove hardcoded Helm repo URLs, reference official docs