### PR TITLE
Add .claude-plugin/plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "mirrord",
+  "description": "Official mirrord skills for Claude Code — Kubernetes development workflows including config generation, quickstart, operator setup, CI integration, and database branching.",
+  "version": "1.0.0",
+  "author": {
+    "name": "MetalBear",
+    "email": "support@metalbear.com",
+    "url": "https://metalbear.co"
+  },
+  "homepage": "https://metalbear.co",
+  "repository": "https://github.com/metalbear-co/skills",
+  "license": "MIT",
+  "keywords": ["mirrord", "kubernetes", "k8s", "metalbear", "dev-tools"]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,9 +5,9 @@
   "author": {
     "name": "MetalBear",
     "email": "support@metalbear.com",
-    "url": "https://metalbear.co"
+    "url": "https://metalbear.com"
   },
-  "homepage": "https://metalbear.co",
+  "homepage": "https://metalbear.com",
   "repository": "https://github.com/metalbear-co/skills",
   "license": "MIT",
   "keywords": ["mirrord", "kubernetes", "k8s", "metalbear", "dev-tools"]


### PR DESCRIPTION
# Add `.claude-plugin/plugin.json`

## Summary

The Claude Code plugin format expects a `.claude-plugin/plugin.json` manifest at the repo root in addition to any `marketplace.json`. We observed the repository ships `.claude-plugin/marketplace.json` (with `source: "./"` pointing at the repo root as the single plugin) and five skills under `skills/`, but no `plugin.json` manifest.

For the plugin to be eligible for inclusion in the public Claude Code plugin marketplace, the manifest needs to be present at the repo root so the plugin's `name`, `version`, `description`, and `author` can be read directly.

This PR adds the manifest derived from the existing `marketplace.json` entry so the plugin resolves cleanly via both the `/plugin marketplace add metalbear-co/skills` install path and repo-root manifest readers.

## Change

Adds a new file: `.claude-plugin/plugin.json`

```json
{
  "name": "mirrord",
  "description": "Official mirrord skills for Claude Code — Kubernetes development workflows including config generation, quickstart, operator setup, CI integration, and database branching.",
  "version": "1.0.0",
  "author": {
    "name": "MetalBear",
    "email": "support@metalbear.com",
    "url": "https://metalbear.co"
  },
  "homepage": "https://metalbear.co",
  "repository": "https://github.com/metalbear-co/skills",
  "license": "MIT",
  "keywords": ["mirrord", "kubernetes", "k8s", "metalbear", "dev-tools"]
}
```

Fields are derived from the existing `marketplace.json` plugin entry (`name: "mirrord"`, `version: "1.0.0"`, the owner block, and the keywords array) plus `license: "MIT"` read from `LICENSE`.

## Notes

- `marketplace.json` is unchanged; the existing `source: "./"` entry still resolves to the repo root.
- The five skills under `skills/mirrord-*/` each already contain `SKILL.md` and are unaffected.

## References

- Plugin components and manifest: https://docs.claude.com/en/docs/claude-code/plugins
- Plugin marketplaces (marketplace.json shape, source kinds): https://docs.claude.com/en/docs/claude-code/plugin-marketplaces

Happy to iterate on any field values or adjust the description if something reads differently from how the skills are positioned in MetalBear's product docs.