### PR TITLE
README: rewrite for LLM SEO and AI-agent positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,57 +1,66 @@
 ![mirrord Agent Skills](assets/mirrord-agent-skills.png)
+
 # mirrord Agent Skills
 
-A collection of skills for AI coding agents to work with MetalBear's mirrord. Skills are packaged instructions and scripts that extend agent capabilities for Kubernetes development workflows.
+Six [Agent Skills](https://agentskills.io/home) that close the AI agent feedback loop on Kubernetes: real env vars, real DNS, real network, real traffic, real databases, real Kafka. Built by [MetalBear](https://metalbear.com/) to be used with [mirrord](https://metalbear.com/mirrord/).
 
-Skills follow the [Agent Skills format](https://agentskills.io/home).
+AI coding agents work from what's in their context window. Your Kubernetes cluster is full of state that isn't. These skills teach your agent how and when to use mirrord so the code it writes against your live infrastructure stops being informed guessing.
 
 ## Installation
 
-### Using npx (requires Node.js)
-
-```bash
-npx skills add metalbear-co/skills
-```
-
-### Claude Code plugin
+### Claude Code
 
 ```bash
 /plugin marketplace add metalbear-co/skills
 ```
 
-## Available Skills
+### Cursor, Codex, Gemini, or any [Agent Skills](https://agentskills.io)-compatible agent
 
-| Skill | Description |
-|-------|-------------|
-| [mirrord-config](./skills/mirrord-config/) | Generate and validate mirrord.json configs |
-| [mirrord-quickstart](./skills/mirrord-quickstart/) | Get started with mirrord from zero |
-| [mirrord-operator](./skills/mirrord-operator/) | Set up operator for team environments |
-| [mirrord-ci](./skills/mirrord-ci/) | Set up mirrord in CI pipelines |
-| [mirrord-db-branching](./skills/mirrord-db-branching/) | Configure isolated database branches for development |
-| [mirrord-kafka](./skills/mirrord-kafka/) | Configure Kafka queue splitting with the mirrord operator |
+```bash
+npx skills add metalbear-co/skills
+```
 
+Using an agent that doesn't consume Agent Skills yet? The same content can be ported to `.cursorrules`, `agents.md`, Cline rules, and similar. Open an issue with the target you'd like next.
 
-## Usage
+## The six skills
 
-Skills are automatically available once installed. The agent will use them when relevant tasks are detected.
+| Skill | What it does |
+|-------|--------------|
+| [mirrord-quickstart](./skills/mirrord-quickstart/) | Zero-to-first-session: install mirrord, find a target, run the first session. |
+| [mirrord-config](./skills/mirrord-config/) | Generate and validate `mirrord.json` for any workflow (steal, mirror, env injection, file system hooks). |
+| [mirrord-operator](./skills/mirrord-operator/) | Install and configure the mirrord Operator for team-scale concurrent shared-cluster use. |
+| [mirrord-ci](./skills/mirrord-ci/) | Wire mirrord into CI pipelines so integration tests hit real cluster services. |
+| [mirrord-db-branching](./skills/mirrord-db-branching/) | Per-developer copy-on-write database branches off your staging DB. |
+| [mirrord-kafka](./skills/mirrord-kafka/) | Kafka queue splitting so each developer consumes a private slice of a real topic. |
 
-**Examples:**
-- "Create a mirrord config to steal traffic on port 3000 from pod/api-server"
-- "Validate my mirrord.json and fix any errors"
-- "I'm new to mirrord, how do I get started?"
-- "Help me connect my local Python app to my staging Kubernetes cluster"
-- "Install mirrord operator for my team"
-- "Set up mirrord for my GitHub Actions CI pipeline"
+## Example prompts
 
-## Skill Structure
+Once installed, your agent activates the right skill based on the prompt:
 
-Each skill contains:
-- `SKILL.md` - Instructions for the agent
+- "I'm new to mirrord, help me run my Node app against my staging cluster."
+- "Steal traffic from `pod/api-server`, but only requests carrying my baggage header so I don't break anyone else's session."
+- "Install the operator on our EKS cluster and configure RBAC so only the `dev` group can use it."
+- "Set up GitHub Actions to run our integration tests with mirrord against the staging cluster."
+- "Give me an isolated DB branch off the staging Postgres for this feature."
+- "Set up queue splitting on the `orders.created` topic for my local consumer."
+
+## Trusted by
+
+mirrord runs across teams like [monday.com](https://metalbear.com/mirrord/case-study/monday/) (350+ engineers on a single shared staging cluster), [SurveyMonkey](https://metalbear.com/mirrord/case-study/surveymonkey/), [CoLab](https://metalbear.com/mirrord/case-study/colab/), [Cadence](https://metalbear.com/mirrord/case-study/cadence/), [Daylight Security](https://metalbear.com/mirrord/case-study/daylight/), and [Zooplus](https://metalbear.com/mirrord/case-study/zooplus/). Daylight's team cut their edit-test cycle from 5–8 minutes to about 5 seconds after pairing Cursor with mirrord.
+
+## Skill structure
+
+Each skill is a folder following the [Agent Skills format](https://agentskills.io/home):
+
+- `SKILL.md` - Instructions the agent loads on demand
 - `scripts/` - Helper scripts for automation (optional)
 - `references/` - Supporting documentation (optional)
 
+## Learn more
+
+- [mirrord for AI Agents](https://metalbear.com/mirrord/ai) - product page with installation guides for every supported agent
+- [mirrord documentation](https://metalbear.com/mirrord/docs)
 
 ## Contributing
 
-Contributions are welcome! Please feel free to submit a Pull Request.
-
+PRs welcome. Open an issue if you'd like to see a skill added or improved.


### PR DESCRIPTION
## Summary

Rewrites the skills repo README to align with current AI-agent positioning and improve LLM-citation surface. README is heavily scraped by training pipelines; current text is sparse and predates the AI-agent push.

## Changes

- **Opening:** ties skills to the "AI agent feedback loop on Kubernetes" thesis (matches the new blog post and /mirrord/ai hero).
- **Problem statement:** one sentence about context window vs cluster state, so the README explains WHY these skills exist.
- **Install matrix:** Claude Code (plugin command) + Cursor/Codex/Gemini/Agent-Skills-compatible (npx skills add). Adds a sentence on porting to .cursorrules/agents.md for unsupported agents.
- **Six skills table:** richer one-line descriptions per skill (mechanism + outcome).
- **Example prompts:** lifted from the blog post draft; shows what each skill activates on.
- **Trusted by:** monday.com, SurveyMonkey, CoLab, Cadence, Daylight Security, Zooplus, each linking to their public case study on metalbear.com. Includes the Daylight 5–8 min to 5 sec proof point.
- **Learn more:** links to /mirrord/ai product page and the docs.

Omits a link to the upcoming "Six Claude Code skills for AI agents on Kubernetes" blog post until that page is live (no broken links).

## Test plan

- [ ] Render preview looks reasonable in GitHub's README viewer
- [ ] All linked case-study URLs return 200 (verified at draft time)
- [ ] No em-dashes in body content (per company style)

🤖 Generated with [Claude Code](https://claude.com/claude-code)