### PR TITLE
mirrord-config: preserve user-provided {{key}} placeholders verbatim

### DIFF
--- a/skills/mirrord-config/SKILL.md
+++ b/skills/mirrord-config/SKILL.md
@@ -115,6 +115,7 @@ User wants changes to their config.
 - mirrord uses Tera templates
 - Example: `"target": "{{ get_env(name=\"TARGET\", default=\"pod/fallback\") }}"`
 - Templates must remain valid JSON
+- When a user provides a literal placeholder like `{{key}}`, use it verbatim — do **not** expand it into a `get_env()` call or any other Tera expression. The user's `{{key}}` is the value they want.
 
 ## Validation Rules
 


### PR DESCRIPTION
When users provide literal placeholders like {{key}} in their config request, the skill was expanding them into Tera get_env() calls. Add guidance to use user-provided template syntax as-is.