### PR TITLE
Add Codex plugin support and an OpenCode installer

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,17 @@
+{
+  "name": "mirrord-skills",
+  "interface": {
+    "displayName": "mirrord Agent Skills"
+  },
+  "plugins": [
+    {
+      "name": "mirrord",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/metalbear-co/skills.git",
+        "ref": "main"
+      },
+      "category": "Development"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,6 +21,7 @@
         "./skills/mirrord-operator",
         "./skills/mirrord-ci",
         "./skills/mirrord-db-branching",
+        "./skills/mirrord-kafka",
         "./skills/mirrord-prev-env"
       ]
     }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "mirrord",
+  "version": "1.0.0",
+  "description": "Official mirrord skills for Codex — Kubernetes development workflows including config generation, quickstart, operator setup, CI integration, database branching, Kafka queue splitting, and preview environments.",
+  "skills": "./skills/",
+  "author": {
+    "name": "MetalBear",
+    "email": "support@metalbear.com",
+    "url": "https://metalbear.com"
+  },
+  "homepage": "https://metalbear.com/mirrord/",
+  "repository": "https://github.com/metalbear-co/skills",
+  "license": "MIT",
+  "keywords": ["mirrord", "kubernetes", "k8s", "metalbear", "dev-tools"]
+}

--- a/README.md
+++ b/README.md
@@ -12,9 +12,36 @@ AI coding agents work from what's in their context window. Your Kubernetes clust
 
 ```bash
 /plugin marketplace add metalbear-co/skills
+/plugin install mirrord@mirrord-skills
 ```
 
-### Cursor, Codex, Gemini, or any [Agent Skills](https://agentskills.io)-compatible agent
+### Codex
+
+```bash
+codex plugin marketplace add metalbear-co/skills
+```
+
+Then install the `mirrord` plugin from `/plugins`. All seven skills come with it.
+
+### OpenCode
+
+OpenCode loads skills natively, so there's nothing to register — the skills just need to be on disk:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/metalbear-co/skills/main/install.sh | sh
+```
+
+That writes the seven skill folders into `~/.config/opencode/skills/`. Restart OpenCode and they're available. Re-run it any time to update — it replaces the `mirrord-*` folders and leaves your other skills alone.
+
+The same script serves any agent that reads a skills directory:
+
+```bash
+sh install.sh --agent codex     # ~/.agents/skills
+sh install.sh --agent claude    # ~/.claude/skills
+sh install.sh --dest <dir>      # anywhere else
+```
+
+### Cursor, Gemini, or any other [Agent Skills](https://agentskills.io)-compatible agent
 
 ```bash
 npx skills add metalbear-co/skills

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,103 @@
+#!/bin/sh
+# Install the mirrord Agent Skills for OpenCode, or any agent that reads a
+# skills directory (Codex, Cursor, Gemini CLI, ...).
+#
+#   curl -fsSL https://raw.githubusercontent.com/metalbear-co/skills/main/install.sh | sh
+#   sh install.sh --agent codex
+#   sh install.sh --dest ~/somewhere/skills
+#
+# Re-running replaces previously installed mirrord-* skills and leaves any
+# other skill in the destination untouched.
+
+set -eu
+
+REPO_URL="https://github.com/metalbear-co/skills.git"
+AGENT="opencode"
+DEST=""
+
+usage() {
+	cat <<'EOF'
+Usage: install.sh [--agent <name>] [--dest <dir>]
+
+  --agent opencode   ~/.config/opencode/skills   (default; honours XDG_CONFIG_HOME)
+  --agent codex      ~/.agents/skills
+  --agent claude     ~/.claude/skills
+  --dest <dir>       install into <dir> instead of an agent default
+EOF
+}
+
+while [ $# -gt 0 ]; do
+	case "$1" in
+	--agent)
+		[ $# -ge 2 ] || { echo "install.sh: --agent needs a value" >&2; exit 2; }
+		AGENT="$2"
+		shift 2
+		;;
+	--dest)
+		[ $# -ge 2 ] || { echo "install.sh: --dest needs a value" >&2; exit 2; }
+		DEST="$2"
+		shift 2
+		;;
+	-h | --help)
+		usage
+		exit 0
+		;;
+	*)
+		echo "install.sh: unknown argument '$1'" >&2
+		usage >&2
+		exit 2
+		;;
+	esac
+done
+
+if [ -z "$DEST" ]; then
+	case "$AGENT" in
+	opencode) DEST="${XDG_CONFIG_HOME:-$HOME/.config}/opencode/skills" ;;
+	codex) DEST="$HOME/.agents/skills" ;;
+	claude) DEST="$HOME/.claude/skills" ;;
+	*)
+		echo "install.sh: unknown agent '$AGENT' (expected opencode, codex, or claude)" >&2
+		exit 2
+		;;
+	esac
+fi
+
+# Use the checkout we're running from when there is one, otherwise fetch a copy.
+# Piped through `curl | sh`, $0 is "sh" and SCRIPT_DIR lands on the caller's cwd,
+# so require markers that only a checkout of this repo has before trusting it.
+SRC=""
+CLONE=""
+SCRIPT_DIR=$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd 2>/dev/null) || SCRIPT_DIR=""
+if [ -n "$SCRIPT_DIR" ] && [ -f "$SCRIPT_DIR/install.sh" ] && [ -d "$SCRIPT_DIR/skills/mirrord-config" ]; then
+	SRC="$SCRIPT_DIR/skills"
+else
+	command -v git >/dev/null 2>&1 || {
+		echo "install.sh: git is required to fetch the skills" >&2
+		exit 1
+	}
+	CLONE=$(mktemp -d)
+	trap 'rm -rf "$CLONE"' EXIT INT TERM
+	git clone --depth 1 --quiet "$REPO_URL" "$CLONE"
+	SRC="$CLONE/skills"
+fi
+
+mkdir -p "$DEST"
+
+count=0
+for skill in "$SRC"/*/; do
+	[ -f "$skill/SKILL.md" ] || continue
+	name=$(basename "$skill")
+	rm -rf "$DEST/$name"
+	cp -R "$skill" "$DEST/$name"
+	echo "  installed $name"
+	count=$((count + 1))
+done
+
+if [ "$count" -eq 0 ]; then
+	echo "install.sh: no skills found in $SRC" >&2
+	exit 1
+fi
+
+echo ""
+echo "$count mirrord skills installed into $DEST"
+echo "Restart $AGENT (or your agent) to pick them up."


### PR DESCRIPTION
## What

Native install paths for **Codex** and **OpenCode**, plus a fix for a missing skill in the Claude Code manifest.

## Codex

Codex has a real plugin system, but the repo had no manifest for it — `codex plugin marketplace add` could only fall back to the legacy `.claude-plugin/` path. This adds:

- `.codex-plugin/plugin.json` — plugin manifest, skills auto-discovered from `./skills/`
- `.agents/plugins/marketplace.json` — marketplace with the plugin at the repo root

```bash
codex plugin marketplace add metalbear-co/skills
codex plugin add mirrord@mirrord-skills
```

Verified end-to-end against the real `codex` CLI: the plugin installs and Codex enumerates all seven skills as `mirrord:mirrord-config`, `mirrord:mirrord-kafka`, and so on.

Note the marketplace `url` source pins to `main`, so this only resolves for users once merged.

## OpenCode

OpenCode's plugin system is for JS/TS event hooks, but it already loads Agent Skills natively from `~/.config/opencode/skills/`. A plugin would be a shim around a feature it ships with, so this adds an install script instead:

```bash
curl -fsSL https://raw.githubusercontent.com/metalbear-co/skills/main/install.sh | sh
```

It's idempotent (replaces `mirrord-*`, leaves other skills alone) and also serves Codex (`--agent codex`), Claude Code (`--agent claude`), or any `--dest`.

## Bug fix

`.claude-plugin/marketplace.json` listed only six skills — **`mirrord-kafka` was missing** while the README advertised seven. Anyone installing via Claude Code has not been getting the Kafka skill. Added.

## Testing

- Installer verified from a local checkout and via the `curl | sh` clone path; all seven skills land with their `references/` intact, and re-running is idempotent.
- Caught and fixed a bug in the piped path: `$0` is `sh` when piped, so the "am I in a checkout?" check resolved to the user's cwd and would have installed an unrelated `skills/` folder if one happened to be there. It now requires markers unique to this repo; verified it ignores a decoy.
- Codex plugin install verified against the local working tree, then the local Codex config restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)