### PR TITLE
Fix docs-sync: pass github_token to claude-code-action

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -59,6 +59,10 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Without this the action falls back to an OIDC exchange with the
+          # Claude GitHub App. This step only edits local files, so the default
+          # token is enough.
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           prompt: "Read .github/docs-sync-prompt.md and follow its instructions exactly."
           claude_args: |
             --model claude-sonnet-5


### PR DESCRIPTION
## Summary

The `docs-sync` workflow has never completed a run. Its only run so far failed at the **Run Claude to update skills** step with:

```
Could not fetch an OIDC token. Did you remember to add `id-token: write` to your workflow permissions?
Operation failed after 3 attempts
```

`claude-code-action@v1` resolves GitHub auth in `setupGitHubToken` before Claude starts. With no `github_token` input it falls back to an OIDC exchange against the Claude GitHub App, which needs both `id-token: write` and the app installed on this repo. Neither is in place.

This passes `github_token: ${{ secrets.GITHUB_TOKEN }}` instead of adding the OIDC permission. That step's Claude only reads and edits local files (`Read,Glob,Grep,Edit,Write,Bash(git diff|log|ls)`) and never calls the GitHub API — the `Commit and open PR` step already uses `secrets.GITHUB_TOKEN` on its own — so the default token is sufficient and this drops the dependency on the app being installed.

## Notes

- The failed run never reached the Anthropic API, so `ANTHROPIC_API_KEY` is still unverified. Worth a look at the key's credit balance before re-running.
- `.github/docs-sync-sha` was not advanced by the failed run, so the same docs commits will be picked up on the next run.

## Test plan

- [ ] Trigger the workflow manually (`workflow_dispatch`) after merge and confirm the Claude step runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)