### PR TITLE
Create PRs with a Cubby app token in scheduled workflows

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -69,10 +69,23 @@ jobs:
             --max-turns 80
             --allowedTools "Read,Glob,Grep,Edit,Write,Bash(git diff:*),Bash(git log:*),Bash(ls:*)"
 
+      # The enterprise blocks GITHUB_TOKEN from creating pull requests, so
+      # gh pr create authenticates as the Cubby app instead (same pattern as
+      # auto-release-pr in mirrord/operator).
+      - name: Create app token for PR creation
+        if: env.skip != 'true'
+        id: app_token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ secrets.CUBBY_CLIENT_ID }}
+          private-key: ${{ secrets.CUBBY_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Commit and open PR
         if: env.skip != 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           echo "$HEAD_SHA" > .github/docs-sync-sha
           rm -rf docs-src

--- a/.github/workflows/update-references.yml
+++ b/.github/workflows/update-references.yml
@@ -27,9 +27,21 @@ jobs:
             https://raw.githubusercontent.com/metalbear-co/mirrord.dev/main/content/docs/reference/configuration.md \
             -o /tmp/configuration.md
 
+      # The enterprise blocks GITHUB_TOKEN from creating pull requests, so
+      # gh pr create authenticates as the Cubby app instead (same pattern as
+      # auto-release-pr in mirrord/operator).
+      - name: Create app token for PR creation
+        id: app_token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ secrets.CUBBY_CLIENT_ID }}
+          private-key: ${{ secrets.CUBBY_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Check for changes, update, and open PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           SCHEMA_CHANGED=false
           CONFIG_CHANGED=false
@@ -128,9 +140,19 @@ jobs:
             https://raw.githubusercontent.com/metalbear-co/charts/main/mirrord-operator/values.yaml \
             -o /tmp/values.yaml
 
+      # See the comment on the twin step in update-references above.
+      - name: Create app token for PR creation
+        id: app_token
+        uses: actions/create-github-app-token@f8d387b68d61c58ab83c6c016672934102569859 # v3.0.0
+        with:
+          app-id: ${{ secrets.CUBBY_CLIENT_ID }}
+          private-key: ${{ secrets.CUBBY_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
+
       - name: Check for changes, update, and open PR
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app_token.outputs.token }}
         run: |
           if diff -q /tmp/values.yaml skills/mirrord-operator/references/values.yaml >/dev/null 2>&1; then
             echo "No changes detected, skipping."


### PR DESCRIPTION
## Summary
The enterprise now blocks the workflow `GITHUB_TOKEN` from creating pull requests, so both scheduled workflows (`docs-sync`, Tuesdays; `update-references`, Mondays) push their branch and then die at `gh pr create` — see [run 30943072524](https://github.com/metalbear-co/skills/actions/runs/30943072524) and [run 30805150865](https://github.com/metalbear-co/skills/actions/runs/30805150865). #48 had to be opened by hand from the pushed branch.

This mints a short-lived token from the **Cubby** GitHub App for the PR-creation step, the same pattern `auto-release-pr` uses in mirrord, operator, and the IDE-extension repos. Side benefit: app-created PRs trigger CI, which `GITHUB_TOKEN`-created PRs never did.

## Prerequisites (done / pending)
- [x] `CUBBY_CLIENT_ID` / `CUBBY_PRIVATE_KEY` org secrets shared with this repo
- [ ] Cubby app installed on this repo (needs an org owner: [installation settings](https://github.com/organizations/metalbear-co/settings/installations))

## Test plan
After the app installation is added, `workflow_dispatch` update-references from main — the token step should mint successfully and any resulting PR should open as `cubby-mb[bot]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)