### PR TITLE
Set `includeAuthors`, `excludeAuthors`, and `disabledLabels` for Greptile

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,3 @@
+{
+  "disabledLabels": ["no-greptile"]
+}

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,3 +1,4 @@
 {
+  "excludeAuthors": ["cubby-mb[bot]"],
   "disabledLabels": ["no-greptile"]
 }

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,4 +1,4 @@
 {
-  "excludeAuthors": ["cubby-mb[bot]"],
+  "excludeAuthors": ["cubby-mb[bot]", "github-actions[bot]"],
   "disabledLabels": ["no-greptile"]
 }

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,4 +1,25 @@
 {
   "excludeAuthors": ["cubby-mb[bot]", "github-actions[bot]"],
+  "includeAuthors": [
+    "0x00A5",
+    "adnazujolakisic",
+    "aris-cub",
+    "aviramha",
+    "cristeigabriela",
+    "DmitryDodzin",
+    "eyalb181",
+    "gememma",
+    "giIuis",
+    "hank-metalbear",
+    "iniw",
+    "itsamegraf",
+    "meowjesty",
+    "MintSoup",
+    "Razz4780",
+    "skreborn",
+    "t4lz",
+    "trawler",
+    "vladrbg"
+  ],
   "disabledLabels": ["no-greptile"]
 }


### PR DESCRIPTION
## Summary

- limit automatic Greptile reviews to 19 frequent contributors
- exclude `cubby-mb[bot]` and `github-actions[bot]` from Greptile reviews
- allow maintainers to suppress an automatic review with the `no-greptile` label

## Why

Automatic reviews should cover frequent contributors whose regular work will use a monthly seat anyway, while occasional contributors and trivial changes should not allocate one by default. Authors outside the allowlist can still receive a Greptile review by tagging Greptile.

Automation-authored pull requests do not need Greptile review. The opt-out label also lets authors and maintainers skip Greptile when an automated review is not needed.
