### PR TITLE
Add ports/: drop-in rules files for GitHub Copilot and Cline

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,9 @@ sh install.sh --dest <dir>      # anywhere else
 npx skills add metalbear-co/skills
 ```
 
-Using an agent that doesn't consume Agent Skills yet? The same content can be ported to `.cursorrules`, `agents.md`, Cline rules, and similar. Open an issue with the target you'd like next.
+### GitHub Copilot, Cline, and other rules-file agents
+
+The [`ports/`](./ports/) directory carries the same core content as drop-in rules files: copy [`ports/github-copilot/copilot-instructions.md`](./ports/github-copilot/copilot-instructions.md) into your repo's `.github/`, or [`ports/cline/.clinerules`](./ports/cline/.clinerules) into your repo root. Want another format? [Open an issue](https://github.com/metalbear-co/skills/issues) with the target you'd like next.
 
 ## The nine skills
 

--- a/ports/README.md
+++ b/ports/README.md
@@ -1,0 +1,14 @@
+# Ports: mirrord rules for agents that don't consume Agent Skills
+
+The nine skills in this repo are the richest way to teach an agent mirrord. If your agent consumes [Agent Skills](https://agentskills.io) (Claude Code, Codex, OpenCode, Cursor, Gemini CLI, and others), use those — see the [main README](../README.md).
+
+These ports carry the same core content as drop-in rules files for agents that don't:
+
+| Agent | File | Where to put it |
+|-------|------|-----------------|
+| GitHub Copilot | [`github-copilot/copilot-instructions.md`](github-copilot/copilot-instructions.md) | `.github/copilot-instructions.md` in your repo |
+| Cline | [`cline/.clinerules`](cline/.clinerules) | `.clinerules` in your repo root |
+
+Copy the file into your repository and the agent picks it up automatically. The content is intentionally compact — rules files load into every prompt — and links to [metalbear.com/agents.md](https://metalbear.com/agents.md) for the fuller operational guide.
+
+Want another format (Windsurf, Zed, JetBrains Junie, ...)? [Open an issue](https://github.com/metalbear-co/skills/issues).

--- a/ports/cline/.clinerules
+++ b/ports/cline/.clinerules
@@ -1,0 +1,31 @@
+# mirrord: run and verify code against the real Kubernetes cluster
+
+This project runs against a Kubernetes cluster. Use mirrord to run and verify code against the cluster's real services: mirrord runs a local process as if it were a pod in the cluster (real env vars, DNS, network, file access, and optionally inbound traffic), with no image build and no deployment.
+
+## When to reach for mirrord
+
+- Before writing code that touches other services, databases, or queues: inspect the real runtime context first.
+- After writing code: run it (or its tests) through mirrord against the cluster to verify it, instead of guessing from static context.
+
+## Commands
+
+- List possible targets: `mirrord ls [-n <namespace>]`
+- Run anything in a target's context: `mirrord exec --target deployment/<name> [-n <namespace>] -- <command>`
+  - Example: `mirrord exec --target deployment/api -- npm test`
+- Inspect a target's environment: `mirrord exec --target deployment/<name> -- env`
+- Install if missing: `brew install metalbear-co/mirrord/mirrord` (macOS/Linux), `choco install --pre mirrord` (Windows), or `curl -fsSL https://raw.githubusercontent.com/metalbear-co/mirrord/main/scripts/install.sh | bash`
+
+## Configuration
+
+- Config lives at `.mirrord/mirrord.json` (picked up automatically), or pass one with `-f <path>`.
+- JSON schema: https://raw.githubusercontent.com/metalbear-co/mirrord/main/mirrord-schema.json
+- `feature.network.incoming` is `"mirror"` (copy the target's inbound traffic), `"steal"` (take it), or `"off"`.
+
+## Rules
+
+- Target staging or development clusters, never production.
+- Default to `"mirror"`. Use `"steal"` only when your process must be the one responding, and prefer an HTTP filter on shared staging so you only take your own requests. Several users or agents stealing concurrently from the same target requires the mirrord Operator (mirrord for Teams).
+- Sessions clean up on exit; nothing you run is deployed to the cluster.
+- If `mirrord ls` fails, verify `kubectl get pods` works first (kubeconfig or permissions).
+
+More for agents: https://metalbear.com/agents.md — Docs: https://metalbear.com/mirrord/docs

--- a/ports/cline/.clinerules
+++ b/ports/cline/.clinerules
@@ -13,11 +13,11 @@ This project runs against a Kubernetes cluster. Use mirrord to run and verify co
 - Run anything in a target's context: `mirrord exec --target deployment/<name> [-n <namespace>] -- <command>`
   - Example: `mirrord exec --target deployment/api -- npm test`
 - Inspect a target's environment: `mirrord exec --target deployment/<name> -- env`
-- Install if missing: `brew install metalbear-co/mirrord/mirrord` (macOS/Linux), `choco install --pre mirrord` (Windows), or `curl -fsSL https://raw.githubusercontent.com/metalbear-co/mirrord/main/scripts/install.sh | bash`
+- If `mirrord` is missing, don't install it yourself and never pipe a remote script into a shell. Point to https://metalbear.com/mirrord/docs/getting-started/installing-mirrord and let the user install it through their organization's approved path.
 
 ## Configuration
 
-- Config lives at `.mirrord/mirrord.json` (picked up automatically), or pass one with `-f <path>`.
+- Config lives at `.mirrord/mirrord.json`, but the CLI does not pick it up on its own: pass it explicitly with `mirrord exec -f .mirrord/mirrord.json -- <command>`. Only the VS Code and JetBrains extensions load it automatically.
 - JSON schema: https://raw.githubusercontent.com/metalbear-co/mirrord/main/mirrord-schema.json
 - `feature.network.incoming` is `"mirror"` (copy the target's inbound traffic), `"steal"` (take it), or `"off"`.
 

--- a/ports/github-copilot/copilot-instructions.md
+++ b/ports/github-copilot/copilot-instructions.md
@@ -1,0 +1,31 @@
+# Using mirrord in this repository
+
+This project runs against a Kubernetes cluster. Use mirrord to run and verify code against the cluster's real services: mirrord runs a local process as if it were a pod in the cluster (real env vars, DNS, network, file access, and optionally inbound traffic), with no image build and no deployment.
+
+## When to reach for mirrord
+
+- Before writing code that touches other services, databases, or queues: inspect the real runtime context first.
+- After writing code: run it (or its tests) through mirrord against the cluster to verify it, instead of guessing from static context.
+
+## Commands
+
+- List possible targets: `mirrord ls [-n <namespace>]`
+- Run anything in a target's context: `mirrord exec --target deployment/<name> [-n <namespace>] -- <command>`
+  - Example: `mirrord exec --target deployment/api -- npm test`
+- Inspect a target's environment: `mirrord exec --target deployment/<name> -- env`
+- Install if missing: `brew install metalbear-co/mirrord/mirrord` (macOS/Linux), `choco install --pre mirrord` (Windows), or `curl -fsSL https://raw.githubusercontent.com/metalbear-co/mirrord/main/scripts/install.sh | bash`
+
+## Configuration
+
+- Config lives at `.mirrord/mirrord.json` (picked up automatically), or pass one with `-f <path>`.
+- JSON schema: https://raw.githubusercontent.com/metalbear-co/mirrord/main/mirrord-schema.json
+- `feature.network.incoming` is `"mirror"` (copy the target's inbound traffic), `"steal"` (take it), or `"off"`.
+
+## Rules
+
+- Target staging or development clusters, never production.
+- Default to `"mirror"`. Use `"steal"` only when your process must be the one responding, and prefer an HTTP filter on shared staging so you only take your own requests. Several users or agents stealing concurrently from the same target requires the mirrord Operator (mirrord for Teams).
+- Sessions clean up on exit; nothing you run is deployed to the cluster.
+- If `mirrord ls` fails, verify `kubectl get pods` works first (kubeconfig or permissions).
+
+More for agents: https://metalbear.com/agents.md — Docs: https://metalbear.com/mirrord/docs

--- a/ports/github-copilot/copilot-instructions.md
+++ b/ports/github-copilot/copilot-instructions.md
@@ -13,11 +13,11 @@ This project runs against a Kubernetes cluster. Use mirrord to run and verify co
 - Run anything in a target's context: `mirrord exec --target deployment/<name> [-n <namespace>] -- <command>`
   - Example: `mirrord exec --target deployment/api -- npm test`
 - Inspect a target's environment: `mirrord exec --target deployment/<name> -- env`
-- Install if missing: `brew install metalbear-co/mirrord/mirrord` (macOS/Linux), `choco install --pre mirrord` (Windows), or `curl -fsSL https://raw.githubusercontent.com/metalbear-co/mirrord/main/scripts/install.sh | bash`
+- If `mirrord` is missing, don't install it yourself and never pipe a remote script into a shell. Point to https://metalbear.com/mirrord/docs/getting-started/installing-mirrord and let the user install it through their organization's approved path.
 
 ## Configuration
 
-- Config lives at `.mirrord/mirrord.json` (picked up automatically), or pass one with `-f <path>`.
+- Config lives at `.mirrord/mirrord.json`, but the CLI does not pick it up on its own: pass it explicitly with `mirrord exec -f .mirrord/mirrord.json -- <command>`. Only the VS Code and JetBrains extensions load it automatically.
 - JSON schema: https://raw.githubusercontent.com/metalbear-co/mirrord/main/mirrord-schema.json
 - `feature.network.incoming` is `"mirror"` (copy the target's inbound traffic), `"steal"` (take it), or `"off"`.
 


### PR DESCRIPTION
## Why

The README's closing line invites porting the skills content to non-Agent-Skills formats ("open an issue with the target you'd like next"). This ships the first two, targeting the largest agent bases that can't consume skills: GitHub Copilot and Cline. Part of the agent-accessibility workstream alongside metalbear.com/agents.md (metalbear.co#505).

## What

- `ports/github-copilot/copilot-instructions.md` — drop into a repo's `.github/`
- `ports/cline/.clinerules` — drop into a repo root
- `ports/README.md` — what these are, install table, pointer back to skills for capable agents
- Main README: the "open an issue" paragraph now points at `ports/` first

Both files share one compact canonical body (when to use mirrord, `ls`/`exec` commands, config + schema link, shared-cluster etiquette: mirror by default, filtered steal, concurrent steal-with-filter = Operator, never production), kept short deliberately since rules files load into every prompt, with metalbear.com/agents.md linked for the full guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)