### PR TITLE
Show full Claude output in docs-sync

### DIFF
--- a/.github/workflows/docs-sync.yml
+++ b/.github/workflows/docs-sync.yml
@@ -63,6 +63,10 @@ jobs:
           # Claude GitHub App. This step only edits local files, so the default
           # token is enough.
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # The action hides the SDK stream by default, which swallows the error
+          # message when a run fails before Claude does any work. This job only
+          # reads public docs and skill files, so there is nothing to redact.
+          show_full_output: true
           prompt: "Read .github/docs-sync-prompt.md and follow its instructions exactly."
           claude_args: |
             --model claude-sonnet-5


### PR DESCRIPTION
## Summary

Every scheduled run of `docs-sync` has failed inside the **Run Claude to update skills** step with `Claude execution failed: result is_error:true`. The action runs with the SDK stream hidden by default (`Running Claude Code via SDK (full output hidden for security)`), so the logs record the failure but not the reason.

The surviving logs show the failing runs die ~270ms after init, at 1 turn and $0 cost — an API-side rejection before Claude does any work, not the agent failing at its task. Config is identical between the failing runs and the one run that got through, so there is nothing left in the workflow to inspect. Without the error text there is no way to tell a rate limit from a quota problem from anything else, and run logs age out — the most recent failure's logs are already unavailable.

`show_full_output: true` makes the next failure carry a readable message. The step only reads `docs/` and `skills/` content, both public, and the action masks registered secrets regardless.

## Notes

- Scheduled runs always use the default branch, so this only takes effect once merged. To exercise it sooner, trigger the workflow manually from Actions after merge.
- The sync marker has not moved since early August, so the next successful run has a backlog of docs commits to process.

🤖 Generated with [Claude Code](https://claude.com/claude-code)